### PR TITLE
OP-2481 Fix ws subscription issue

### DIFF
--- a/src/services/OrionAggregator/ws/index.ts
+++ b/src/services/OrionAggregator/ws/index.ts
@@ -254,14 +254,14 @@ class OrionAggregatorWS {
   }
 
   destroy() {
-    this.ws?.close(4000);
+    this.ws?.close();
     delete this.ws;
   }
 
   init(isReconnect = false) {
     this.ws = new WebSocket(this.wsUrl);
     this.ws.onclose = (e) => {
-      if (e.code !== 4000) this.init(true);
+      if (this.ws) this.init(true);
     };
     this.ws.onopen = () => {
       // Re-subscribe to all subscriptions

--- a/src/services/PriceFeed/ws/PriceFeedSubscription.ts
+++ b/src/services/PriceFeed/ws/PriceFeedSubscription.ts
@@ -108,7 +108,7 @@ export default class PriceFeedSubscription<T extends SubscriptionType = Subscrip
 
     this.ws.onclose = (e) => {
       if (this.heartbeatInterval) clearInterval(this.heartbeatInterval);
-      if (e.code !== 4000) this.init();
+      if (this.ws) this.init();
     };
 
     this.heartbeatInterval = setInterval(() => {
@@ -117,6 +117,7 @@ export default class PriceFeedSubscription<T extends SubscriptionType = Subscrip
   }
 
   kill() {
-    this.ws?.close(4000);
+    this.ws?.close();
+    delete this.ws;
   }
 }


### PR DESCRIPTION
В виду того, что вебсокет при определенных обстоятельствах присылает код закрытия 1006, даже если мы сами инициализировали это закрытие, потребовалось провести данный рафакторинг.
подсмотрел в `src/services/OrionAggregator/ws/index.ts` на 258 строку и сделал соответственно в `src/services/PriceFeed/ws/PriceFeedSubscription.ts`. И в итоге сделал логику переподключения одинаковой в обоих случаях чтобы наверняка не происходило неявного переподключения.

О причинах говорится здесь https://stackoverflow.com/questions/19304157/getting-the-reason-why-websockets-closed-with-close-code-1006?answertab=trending#tab-top
```
Note that Chrome will often report a close code 1006 if there is an error during the HTTP Upgrade to Websocket (this is the step before a WebSocket is technically "connected"). For reasons such as bad authentication or authorization, or bad protocol use (such as requesting a subprotocol, but the server itself doesn't support that same subprotocol), or even an attempt at talking to a server location that isn't a WebSocket (such as attempting to connect to ws://images.google.com/)
```

суть в том, что даже если мы передаем код (например 4000), то браузер может изменить его на 1006, что не соответствует нашим ожиданиям.