### PR TITLE
Add new methods to PriceFeed class to get statistics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orionprotocol/sdk",
-  "version": "0.15.18",
+  "version": "0.15.19-rc.0",
   "description": "Orion Protocol SDK",
   "main": "./lib/esm/index.js",
   "module": "./lib/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orionprotocol/sdk",
-  "version": "0.15.19-rc.0",
+  "version": "0.15.19-rc.1",
   "description": "Orion Protocol SDK",
   "main": "./lib/esm/index.js",
   "module": "./lib/esm/index.js",

--- a/src/services/PriceFeed/index.ts
+++ b/src/services/PriceFeed/index.ts
@@ -1,4 +1,5 @@
 import fetchWithValidation from '../../fetchWithValidation';
+import { Exchange } from '../../types';
 import { statisticsOverviewSchema, topPairsStatisticsSchema } from './schemas';
 import candlesSchema from './schemas/candlesSchema';
 import { PriceFeedWS } from './ws';
@@ -22,7 +23,7 @@ class PriceFeed {
     timeStart: number,
     timeEnd: number,
     interval: '5m' | '30m' | '1h' | '1d',
-    exchange = 'all',
+    exchange = 'all'
   ) => {
     const url = new URL(this.candlesUrl);
     url.searchParams.append('symbol', symbol);
@@ -34,14 +35,14 @@ class PriceFeed {
     return fetchWithValidation(url.toString(), candlesSchema);
   };
 
-  getStatisticsOverview(exchange = 'ALL') {
+  getStatisticsOverview(exchange: Exchange | 'ALL' = 'ALL') {
     const url = new URL(`${this.statisticsUrl}/overview`);
     url.searchParams.append('exchange', exchange);
 
     return fetchWithValidation(url.toString(), statisticsOverviewSchema);
   }
 
-  getTopPairStatistics(exchange = 'ALL') {
+  getTopPairStatistics(exchange: Exchange | 'ALL' = 'ALL') {
     const url = new URL(`${this.statisticsUrl}/top-pairs`);
     url.searchParams.append('exchange', exchange);
 

--- a/src/services/PriceFeed/index.ts
+++ b/src/services/PriceFeed/index.ts
@@ -1,4 +1,5 @@
 import fetchWithValidation from '../../fetchWithValidation';
+import { statisticsOverviewSchema, topPairsStatisticsSchema } from './schemas';
 import candlesSchema from './schemas/candlesSchema';
 import { PriceFeedWS } from './ws';
 
@@ -12,6 +13,8 @@ class PriceFeed {
     this.ws = new PriceFeedWS(this.wsUrl);
 
     this.getCandles = this.getCandles.bind(this);
+    this.getStatisticsOverview = this.getStatisticsOverview.bind(this);
+    this.getTopPairStatistics = this.getTopPairStatistics.bind(this);
   }
 
   getCandles = (
@@ -28,11 +31,22 @@ class PriceFeed {
     url.searchParams.append('interval', interval);
     url.searchParams.append('exchange', exchange);
 
-    return fetchWithValidation(
-      url.toString(),
-      candlesSchema,
-    );
+    return fetchWithValidation(url.toString(), candlesSchema);
   };
+
+  getStatisticsOverview(exchange = 'ALL') {
+    const url = new URL(`${this.statisticsUrl}/overview`);
+    url.searchParams.append('exchange', exchange);
+
+    return fetchWithValidation(url.toString(), statisticsOverviewSchema);
+  }
+
+  getTopPairStatistics(exchange = 'ALL') {
+    const url = new URL(`${this.statisticsUrl}/top-pairs`);
+    url.searchParams.append('exchange', exchange);
+
+    return fetchWithValidation(url.toString(), topPairsStatisticsSchema);
+  }
 
   get wsUrl() {
     const url = new URL(this.apiUrl);
@@ -43,10 +57,12 @@ class PriceFeed {
   get candlesUrl() {
     return `${this.apiUrl}/api/v1/candles`;
   }
+
+  get statisticsUrl() {
+    return `${this.apiUrl}/api/v1/statistics`;
+  }
 }
 
 export * as schemas from './schemas';
 
-export {
-  PriceFeed,
-};
+export { PriceFeed };

--- a/src/services/PriceFeed/schemas/index.ts
+++ b/src/services/PriceFeed/schemas/index.ts
@@ -1,1 +1,5 @@
 export { default as candlesSchema } from './candlesSchema';
+export {
+  statisticsOverviewSchema,
+  topPairsStatisticsSchema,
+} from './statisticsSchema';

--- a/src/services/PriceFeed/schemas/statisticsSchema.ts
+++ b/src/services/PriceFeed/schemas/statisticsSchema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const statisticsOverview = z.object({
+  volume24h: z.number(),
+  volume7d: z.number(),
+});
+
+export const statisticsOverviewSchema = z.object({
+  time: z.number(),
+  statisticsOverview,
+});
+
+export const topPairsStatisticsSchema = z.object({
+  time: z.number(),
+  topPairs: z.array(
+    z.object({
+      assetPair: z.string(),
+      statisticsOverview,
+    }),
+  ),
+});


### PR DESCRIPTION
Добавил методы `getStatisticsOverview` и `getTopPairStatistics` для получения статистических данных.

Эндпоинты в swagger [/statistics/overviewUsingGET](https://trade-exp.orionprotocol.io/price-feed/swagger-ui/index.html#/statistics/overviewUsingGET) и [statistics/topPairsUsingGET](https://trade-exp.orionprotocol.io/price-feed/swagger-ui/index.html#/statistics/topPairsUsingGET) соответственно.